### PR TITLE
Screw the rules!

### DIFF
--- a/src/ExamplePackage.jl
+++ b/src/ExamplePackage.jl
@@ -38,5 +38,6 @@ export output_string, added_function
 
 include("output_string.jl")
 include("my_new_file.jl")
+include("might_be_a_bad_idea.jl")
 
 end # module

--- a/src/might_be_a_bad_idea.jl
+++ b/src/might_be_a_bad_idea.jl
@@ -1,0 +1,1 @@
+Base.eps(x::Integer) = 2


### PR DESCRIPTION
This overloads the `eps` function so that we can be rebels!

```julia
eps(10) == 2
```

Note I did not add tests because I'm a bad boy!